### PR TITLE
Update SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,41 +1,17 @@
-<!-- BEGIN MICROSOFT SECURITY.MD V0.0.9 BLOCK -->
+# Reporting Security Issues
 
-## Security
+The Munson's Pickles and Preserves team take security bugs in Team Messaging System seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
 
-Microsoft takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Microsoft](https://github.com/Microsoft), [Azure](https://github.com/Azure), [DotNet](https://github.com/dotnet), [AspNet](https://github.com/aspnet) and [Xamarin](https://github.com/xamarin).
+To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/electron/electron/security/advisories/new) tab.
 
-If you believe you have found a security vulnerability in any Microsoft-owned repository that meets [Microsoft's definition of a security vulnerability](https://aka.ms/security.md/definition), please report it to us as described below.
+The Electron team will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.
 
-## Reporting Security Issues
+Report security bugs in third-party modules to the person or team maintaining the module. You can also report a vulnerability through the [npm contact form](https://www.npmjs.com/support) by selecting "I'm reporting a security vulnerability".
 
-**Please do not report security vulnerabilities through public GitHub issues.**
+## The Electron Security Notification Process
 
-Instead, please report them to the Microsoft Security Response Center (MSRC) at [https://msrc.microsoft.com/create-report](https://aka.ms/security.md/msrc/create-report).
+For context on Electron's security notification process, please see the [Notifications](https://github.com/electron/governance/blob/main/wg-security/membership-and-notifications.md#notifications) section of the Security WG's [Membership and Notifications](https://github.com/electron/governance/blob/main/wg-security/membership-and-notifications.md) Governance document.
 
-If you prefer to submit without logging in, send email to [secure@microsoft.com](mailto:secure@microsoft.com).  If possible, encrypt your message with our PGP key; please download it from the [Microsoft Security Response Center PGP Key page](https://aka.ms/security.md/msrc/pgp).
+## Learning More About Security
 
-You should receive a response within 24 hours. If for some reason you do not, please follow up via email to ensure we received your original message. Additional information can be found at [microsoft.com/msrc](https://www.microsoft.com/msrc). 
-
-Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
-
-  * Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
-  * Full paths of source file(s) related to the manifestation of the issue
-  * The location of the affected source code (tag/branch/commit or direct URL)
-  * Any special configuration required to reproduce the issue
-  * Step-by-step instructions to reproduce the issue
-  * Proof-of-concept or exploit code (if possible)
-  * Impact of the issue, including how an attacker might exploit the issue
-
-This information will help us triage your report more quickly.
-
-If you are reporting for a bug bounty, more complete reports can contribute to a higher bounty award. Please visit our [Microsoft Bug Bounty Program](https://aka.ms/security.md/msrc/bounty) page for more details about our active programs.
-
-## Preferred Languages
-
-We prefer all communications to be in English.
-
-## Policy
-
-Microsoft follows the principle of [Coordinated Vulnerability Disclosure](https://aka.ms/security.md/cvd).
-
-<!-- END MICROSOFT SECURITY.MD BLOCK -->
+To learn more about securing an Electron application, please see the [security tutorial](docs/tutorial/security.md).


### PR DESCRIPTION
This pull request includes significant updates to the `SECURITY.md` file to tailor the security reporting guidelines specifically for the Munson's Pickles and Preserves team and the Electron project. The most important changes include updating the reporting process, removing references to Microsoft-specific procedures, and providing resources for learning more about security.

### Updates to Security Reporting Guidelines:

* **Reporting Security Issues**: Updated the instructions to use the GitHub Security Advisory "Report a Vulnerability" tab for reporting security issues. Added details on how the Electron team will handle the report. (`SECURITY.md`)
* **Third-Party Modules**: Added guidance to report security bugs in third-party modules to the respective maintainers or through the npm contact form. (`SECURITY.md`)

### Removal of Microsoft-Specific Procedures:

* **Microsoft References**: Removed references to Microsoft’s security procedures, including the Microsoft Security Response Center (MSRC) and Microsoft Bug Bounty Program. (`SECURITY.md`)
* **Preferred Languages and Policy**: Removed sections on preferred languages for communication and Microsoft’s Coordinated Vulnerability Disclosure policy. (`SECURITY.md`)

### Resources for Learning More About Security:

* **Electron Security Notification Process**: Added a section to provide context on Electron's security notification process, with links to relevant governance documents. (`SECURITY