### PR TITLE
namespace Linq Resolves #9

### DIFF
--- a/src/Application/src/RazorPagesTestSample/Pages/Index.cshtml.cs
+++ b/src/Application/src/RazorPagesTestSample/Pages/Index.cshtml.cs
@@ -7,6 +7,7 @@ using RazorPagesTestSample.Data;
 using System.Threading;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 
 namespace RazorPagesTestSample.Pages
 {


### PR DESCRIPTION
This pull request includes a small change to the `Index.cshtml.cs` file. The change adds the `System.Linq` namespace to the list of using directives.

* [`src/Application/src/RazorPagesTestSample/Pages/Index.cshtml.cs`](diffhunk://#diff-253887119f1aeea8f5bd6fecc53ddcd5cd2d601f4e80af86ffaf52338d40f7d4R10): Added `using System.Linq` to the list of using directives.