### PR TITLE
Add Redis cache resource to main.bicep

### DIFF
--- a/src/InfrastructureAsCode/main.bicep
+++ b/src/InfrastructureAsCode/main.bicep
@@ -100,6 +100,18 @@ resource appServiceApp 'Microsoft.Web/sites@2020-12-01' = {
     }
 }
 
+resource redisCache 'Microsoft.Cache/Redis@2020-06-01' = {
+  name: 'myRedisCache'
+  location: location
+  properties: {
+    sku: {
+      name: 'Basic'
+      family: 'C'
+      capacity: 0
+    }
+  }
+}
+
 output application_name string = appServiceApp.name
 output application_url string = appServiceApp.properties.hostNames[0]
 output container_registry_name string = containerRegistry.name


### PR DESCRIPTION
This pull request adds a new Redis Cache resource to the infrastructure as code configuration. The most important change is the inclusion of the Redis Cache resource definition.

Infrastructure as Code:

* [`src/InfrastructureAsCode/main.bicep`](diffhunk://#diff-a705772ad6c700e9d296ea9fb26de5e54a731a73bf57caf1f56f6bb3dbed2869R103-R114): Added a new resource definition for `Microsoft.Cache/Redis@2020-06-01` with basic SKU configuration.