### PR TITLE
Add Redis cache resource with dynamic name to main.bicep

### DIFF
--- a/src/InfrastructureAsCode/main.bicep
+++ b/src/InfrastructureAsCode/main.bicep
@@ -13,6 +13,7 @@ var registryName = '${uniqueString(resourceGroup().id)}mpnpreg'
 var registrySku = 'Standard'
 var imageName = 'techexcel/dotnetcoreapp'
 var startupCommand = ''
+var redisCacheName = '${uniqueString(resourceGroup().id)}-mpnp-redis'
 
 
 resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2021-12-01-preview' = {
@@ -101,7 +102,7 @@ resource appServiceApp 'Microsoft.Web/sites@2020-12-01' = {
 }
 
 resource redisCache 'Microsoft.Cache/Redis@2020-06-01' = {
-  name: 'myRedisCache'
+  name: 'redisCacheName'
   location: location
   properties: {
     sku: {


### PR DESCRIPTION
This pull request includes changes to the `src/InfrastructureAsCode/main.bicep` file to improve the naming conventions for resources and ensure consistency across the codebase. The most important changes include adding a new variable for the Redis Cache name and updating the Redis Cache resource to use this variable.

Naming conventions and consistency improvements:

* [`src/InfrastructureAsCode/main.bicep`](diffhunk://#diff-a705772ad6c700e9d296ea9fb26de5e54a731a73bf57caf1f56f6bb3dbed2869R16): Added a new variable `redisCacheName` to store the Redis Cache name, ensuring it uses a unique string based on the resource group ID.
* [`src/InfrastructureAsCode/main.bicep`](diffhunk://#diff-a705772ad6c700e9d296ea9fb26de5e54a731a73bf57caf1f56f6bb3dbed2869L104-R105): Updated the Redis Cache resource to use the `redisCacheName` variable instead of a hardcoded name.